### PR TITLE
Making Join and TableModify fields extraction RelVisitor work

### DIFF
--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -19,17 +19,17 @@ public class Main {
         String scanFilterProjectAll = "SELECT * FROM employees WHERE `id` IN (100,2,3,4)";
         String scanFilterProjectOne = "SELECT `age` FROM employees WHERE `age` < 30";
         String scanFilterProjectTwo = "SELECT `first`, `age` FROM employees WHERE `age` < 30";
-        String tableModify = "INSERT INTO `employees` (`id`, `age`,`first`,`last`) VALUES (9, 20, 'ime', 'prezime')";
+        String tableModify = "INSERT INTO `employees` (`id`, `age`,`first`,`last`,`city_id`) VALUES (9, 20, 'ime', 'prezime',1)";
 
         String dbSettingsFile = "application/src/main/resources/calcite.properties";
 
         //execute(scanProjectAll, dbSettingsFile); // works
-        //execute(scanJoinFilterProjectAll, dbSettingsFile);
-        execute(scanProjectOne, dbSettingsFile); // works
+        //execute(scanJoinFilterProjectAll, dbSettingsFile); // works
+        //execute(scanProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectAll, dbSettingsFile); // works
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
-        //execute(tableModify, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+        execute(tableModify, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
     }
 
     private static void execute(String query, String dbSettingsFile) {

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -24,8 +24,8 @@ public class Main {
         String dbSettingsFile = "application/src/main/resources/calcite.properties";
 
         //execute(scanProjectAll, dbSettingsFile); // works
-        execute(scanJoinFilterProjectAll, dbSettingsFile);
-        //execute(scanProjectOne, dbSettingsFile); // works
+        //execute(scanJoinFilterProjectAll, dbSettingsFile);
+        execute(scanProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectAll, dbSettingsFile); // works
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -33,10 +33,10 @@ public class Main {
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
 
-        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now -- should show entire table
-        //execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
-        execute(tableModifyUpdatePartial, dbSettingsFile); // FIXME: doesn't work we don't handle operation=[UPDATE], updateColumnList=[[age]]
-        //execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
+        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now -- should show entire table -- currently shows mc_db.employees.ROWCOUNT
+        execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
+        execute(tableModifyUpdatePartial, dbSettingsFile); // works - but, using exception to interrupt RelVisitor
+        execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
     }
 
     private static void execute(String query, String dbSettingsFile) {

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -33,8 +33,8 @@ public class Main {
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
 
-        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now -- should show entire table -- currently shows mc_db.employees.ROWCOUNT
-        execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
+        execute(tableModifyInsert, dbSettingsFile); // works - shows entire table
+        execute(tableModifyUpdate, dbSettingsFile); // works - but, using exception to interrupt RelVisitor
         execute(tableModifyUpdatePartial, dbSettingsFile); // works - but, using exception to interrupt RelVisitor
         execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
     }

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -34,9 +34,9 @@ public class Main {
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
 
         execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now -- should show entire table
-        execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
+        //execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
         execute(tableModifyUpdatePartial, dbSettingsFile); // FIXME: doesn't work we don't handle operation=[UPDATE], updateColumnList=[[age]]
-        execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
+        //execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
     }
 
     private static void execute(String query, String dbSettingsFile) {

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -19,7 +19,10 @@ public class Main {
         String scanFilterProjectAll = "SELECT * FROM employees WHERE `id` IN (100,2,3,4)";
         String scanFilterProjectOne = "SELECT `age` FROM employees WHERE `age` < 30";
         String scanFilterProjectTwo = "SELECT `first`, `age` FROM employees WHERE `age` < 30";
-        String tableModify = "INSERT INTO `employees` (`id`, `age`,`first`,`last`,`city_id`) VALUES (9, 20, 'ime', 'prezime',1)";
+        String tableModifyInsert = "INSERT INTO `employees` (`id`, `age`,`first`,`last`,`city_id`) VALUES (13, 20, 'Ivan', 'Grgurina', 1)";
+        String tableModifyUpdate = "UPDATE `mc_db`.`employees` SET `id` = 13, `age` = 17, `first` = 'Ivan', `last` = 'Grgurina', `city_id` = 1 WHERE `id` = 13";
+        String tableModifyUpdatePartial = "UPDATE `mc_db`.`employees` SET `age` = 25 WHERE `id` = 13";
+        String tableModifyDelete = "DELETE FROM `mc_db`.`employees` WHERE `id` = 13";
 
         String dbSettingsFile = "application/src/main/resources/calcite.properties";
 
@@ -29,7 +32,11 @@ public class Main {
         //execute(scanFilterProjectAll, dbSettingsFile); // works
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
-        execute(tableModify, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+
+        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+        execute(tableModifyUpdate, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+        execute(tableModifyUpdatePartial, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+        execute(tableModifyDelete, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
     }
 
     private static void execute(String query, String dbSettingsFile) {

--- a/application/src/main/java/cloud/sec/application/Main.java
+++ b/application/src/main/java/cloud/sec/application/Main.java
@@ -33,10 +33,10 @@ public class Main {
         //execute(scanFilterProjectOne, dbSettingsFile); // works
         //execute(scanFilterProjectTwo, dbSettingsFile); // works
 
-        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
-        execute(tableModifyUpdate, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
-        execute(tableModifyUpdatePartial, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
-        execute(tableModifyDelete, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now
+        execute(tableModifyInsert, dbSettingsFile); // FIXME: doesn't work because we don't handle TableModify right now -- should show entire table
+        execute(tableModifyUpdate, dbSettingsFile); // works - shows entire table
+        execute(tableModifyUpdatePartial, dbSettingsFile); // FIXME: doesn't work we don't handle operation=[UPDATE], updateColumnList=[[age]]
+        execute(tableModifyDelete, dbSettingsFile); // works - shows entire table
     }
 
     private static void execute(String query, String dbSettingsFile) {

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -46,6 +46,7 @@ public class MultiCloudDataManager {
 
                 if (node instanceof TableScan || node instanceof TableModify) {
                     tables.put(node.getTable(), getFieldNames(node));
+                    //TODO: if it's TableModify, insert fields right here
                 }
 
                 if (node instanceof Project) {

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -22,101 +22,6 @@ public class MultiCloudDataManager {
     private static final Logger logger = LoggerFactory.getLogger(MultiCloudDataManager.class);
     private static final RelWriter rw = new RelWriterImpl(new PrintWriter(System.out, true));
 
-    public static Set<RelOptTable> findTables(final RelNode node) {
-        final Set<RelOptTable> tables = Sets.newLinkedHashSet();
-
-        // tableVisitor
-        new RelVisitor() {
-            @Override
-            public void visit(RelNode node, int ordinal, RelNode parent) {
-                if (node instanceof TableScan || node instanceof TableModify) {
-                    tables.add(node.getTable());
-                }
-                super.visit(node, ordinal, parent);
-            }
-        }.go(node);
-
-        return tables;
-    }
-
-    // FIXME: make this return something...
-    // TODO: maybe I don't even need this.
-    public static void handle(Project project) {
-        new RelVisitor() {
-
-            @Override
-            // EXPLAIN: initial input is a child of pNode = project node. go through the tree and discover first scan, that should be the correct one
-            public void visit(RelNode pNode, int ordinal, RelNode parent) {
-                if (pNode instanceof TableScan) {
-                    // EXPLAIN: if it's a Table Scan, this is most likely the correct one
-
-                    final TableScan scan = (TableScan) pNode;
-                    // EXPLAIN: get information about table
-                    RelOptTable table = scan.getTable();
-                    String schemaName = table.getQualifiedName().get(0);
-                    String tableName = table.getQualifiedName().get(1);
-
-                    // TODO: add check that Project->Fields are subset of TableScan->Fields to confirm this is a correct TableScan - in case of Join, this is more complicated
-                    for (RelDataTypeField relDataTypeField : table.getRowType().getFieldList()) {
-                        relDataTypeField.getName();
-                    }
-
-                    // EXPLAIN: go through the list of fields in Project and add them to the usedFields, together with discovered TableScan schema and table names.
-//                    for (Pair<RexNode, String> field : namedProjects) {
-//                        String fieldName = field.getValue();
-//                        usedFields.add(MultiCloudField.of(schemaName, tableName, fieldName));
-//                    }
-                } else if (pNode instanceof Join) {
-                    // EXPLAIN: if it's a Join, we need to start new relVisitors on each branch
-                    // TODO: add relVisitors on each child branch of JOIN
-                    Join join = (Join) pNode;
-                    if (join.getInputs().size() != 2) {
-                        // Bail out
-                        throw new ReturnedValue(false);
-                    }
-
-                    // FIXME: ADD REAL HANDLERS FOR JOIN
-                    // TODO: join handler should look for tableScan, another join or project
-                    // First branch should have the query (with write ID filter conditions)
-                    new RelVisitor() {
-                        @Override
-                        public void visit(RelNode node, int ordinal, RelNode parent) {
-                            if (node instanceof TableScan ||
-                                    node instanceof Filter ||
-                                    node instanceof Project ||
-                                    node instanceof Join) {
-                                // We can continue
-                                super.visit(node, ordinal, parent);
-                            } else if (node instanceof Aggregate) {
-                                // We can continue
-                                super.visit(node, ordinal, parent);
-                            } else {
-                                throw new ReturnedValue(false);
-                            }
-                        }
-                    }.go(join.getInput(0));
-                    // Second branch should only have the MV
-                    new RelVisitor() {
-                        @Override
-                        public void visit(RelNode node, int ordinal, RelNode parent) {
-                            if (node instanceof TableScan) {
-                                // We can continue
-                                // TODO: Need to check that this is the same MV that we are rebuilding
-                                RelOptTable table = (RelOptTable) node.getTable();
-
-                            } else if (node instanceof Project) {
-                                // We can continue
-                                super.visit(node, ordinal, parent);
-                            }
-                        }
-                    }.go(join.getInput(1));
-                }
-
-                // EXPLAIN: otherwise, continue to next child
-                super.visit(pNode, ordinal, parent);
-            }
-        }.go(project.getInput(0)); // EXPLAIN: Project always has single child
-    }
 
     public static MultiCloudFieldSet findFields(final RelNode node) {
         logger.debug("RelVisitor:Init");
@@ -129,7 +34,7 @@ public class MultiCloudDataManager {
         //              if(table.fields.contains(project.field)) { -- match
         //                  do stuff.
 
-        final Set<MultiCloudField<String, String, String>> usedFields = Sets.newLinkedHashSet();
+        final Set<MultiCloudField<String, String, String>> usedFields = new HashSet<>();
 
         Map<RelOptTable, Set<String>> tables = new HashMap<>();
         Set<String> projects = new HashSet<>();
@@ -143,18 +48,15 @@ public class MultiCloudDataManager {
                     tables.put(node.getTable(), getFieldNames(node));
                 }
 
-                if (node instanceof Project) { // EXPLAIN: if it's a Project, we want to find him a matching TableScan OR Join->TableScans to get Schema and Table information
+                if (node instanceof Project) {
                     projects.addAll(getFieldNames(node));
-
-                    //EXPLAIN: lets ignore Project handler for now, maybe we can get information we need without it
-                    // handle((Project) node);
                 }
 
                 super.visit(node, ordinal, parent); // visit children
             }
         }.go(node);
 
-        // TODO: can we map them now? Yes, we can!
+        // EXPLAIN: can we map them now? Yes, we can!
         for (String projectFieldName : projects) {
             tables.forEach((table, fields) -> {
                 if(fields.contains(projectFieldName)) {
@@ -192,16 +94,5 @@ public class MultiCloudDataManager {
         getFields(node).forEach(field -> names.add(field.getName()));
 
         return names;
-    }
-
-    /**
-     * Exception used to interrupt a visitor walk.
-     */
-    private static class ReturnedValue extends ControlFlowException {
-        private final boolean value;
-
-        public ReturnedValue(boolean value) {
-            this.value = value;
-        }
     }
 }

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -148,20 +148,19 @@ public class MultiCloudDataManager {
 
                     //EXPLAIN: lets ignore Project handler for now, maybe we can get information we need without it
                     // handle((Project) node);
-
                 }
 
                 super.visit(node, ordinal, parent); // visit children
             }
         }.go(node);
 
-        // TODO: can we map them now?
-        for (RelDataTypeField field : projects) {
+        // TODO: can we map them now? Yes, we can!
+        for (String projectFieldName : projects) {
             tables.forEach((table, fields) -> {
-                if(fields.contains(field)) {
+                if(fields.contains(projectFieldName)) {
                     String schemaName = table.getQualifiedName().get(0);
                     String tableName = table.getQualifiedName().get(1);
-                    usedFields.add(MultiCloudField.of(schemaName, tableName, field.getName()));
+                    usedFields.add(MultiCloudField.of(schemaName, tableName, projectFieldName));
                 }
             });
         }

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -76,7 +76,7 @@ public class MultiCloudDataManager {
 
                     //TODO: if it's TableModify INSERT, insert all table fields fields right here
                     if (operation == TableModify.Operation.INSERT) {
-                        fieldNames = getFieldNames(tableModify.deriveRowType().getFieldList());
+                        fieldNames = getFieldNames(tableModify.getTable().getRowType().getFieldList());
                     }
 
                     //TODO: if it's UPDATE, check operation=[UPDATE], updateColumnList=[[age]]
@@ -85,6 +85,7 @@ public class MultiCloudDataManager {
                     }
 
                     // TODO: handle mapping for INSERT and UPDATE here, since they're special
+                    // this doesn't trigger for DELETE because fieldNames are empty
                     for (String field : fieldNames) {
                         usedFields.add(MultiCloudField.of(schemaName, tableName, field));
                     }

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -10,9 +10,7 @@ import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.*;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
 import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ControlFlowException;
-import org.apache.calcite.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,16 +40,94 @@ public class MultiCloudDataManager {
         return tables;
     }
 
+    // TODO: make this return something...
+    public static void handle(Project project) {
+        new RelVisitor() {
+
+            @Override
+            // EXPLAIN: initial input is a child of pNode = project node. go through the tree and discover first scan, that should be the correct one
+            public void visit(RelNode pNode, int ordinal, RelNode parent) {
+                if (pNode instanceof TableScan) {
+                    // EXPLAIN: if it's a Table Scan, this is most likely the correct one
+
+                    final TableScan scan = (TableScan) pNode;
+                    // EXPLAIN: get information about table
+                    RelOptTable table = scan.getTable();
+                    String schemaName = table.getQualifiedName().get(0);
+                    String tableName = table.getQualifiedName().get(1);
+
+                    // TODO: add check that Project->Fields are subset of TableScan->Fields to confirm this is a correct TableScan - in case of Join, this is more complicated
+                    for (RelDataTypeField relDataTypeField : table.getRowType().getFieldList()) {
+                        relDataTypeField.getName();
+                    }
+
+                    // EXPLAIN: go through the list of fields in Project and add them to the usedFields, together with discovered TableScan schema and table names.
+//                    for (Pair<RexNode, String> field : namedProjects) {
+//                        String fieldName = field.getValue();
+//                        usedFields.add(MultiCloudField.of(schemaName, tableName, fieldName));
+//                    }
+                } else if (pNode instanceof Join) {
+                    // EXPLAIN: if it's a Join, we need to start new relVisitors on each branch
+                    // TODO: add relVisitors on each child branch of JOIN
+                    Join join = (Join) pNode;
+                    if (join.getInputs().size() != 2) {
+                        // Bail out
+                        throw new ReturnedValue(false);
+                    }
+
+                    // FIXME: ADD REAL HANDLERS FOR JOIN
+                    // TODO: join handler should look for tableScan, another join or project
+                    // First branch should have the query (with write ID filter conditions)
+                    new RelVisitor() {
+                        @Override
+                        public void visit(RelNode node, int ordinal, RelNode parent) {
+                            if (node instanceof TableScan ||
+                                    node instanceof Filter ||
+                                    node instanceof Project ||
+                                    node instanceof Join) {
+                                // We can continue
+                                super.visit(node, ordinal, parent);
+                            } else if (node instanceof Aggregate) {
+                                // We can continue
+                                super.visit(node, ordinal, parent);
+                            } else {
+                                throw new ReturnedValue(false);
+                            }
+                        }
+                    }.go(join.getInput(0));
+                    // Second branch should only have the MV
+                    new RelVisitor() {
+                        @Override
+                        public void visit(RelNode node, int ordinal, RelNode parent) {
+                            if (node instanceof TableScan) {
+                                // We can continue
+                                // TODO: Need to check that this is the same MV that we are rebuilding
+                                RelOptTable table = (RelOptTable) node.getTable();
+
+                            } else if (node instanceof Project) {
+                                // We can continue
+                                super.visit(node, ordinal, parent);
+                            }
+                        }
+                    }.go(join.getInput(1));
+                }
+
+                // EXPLAIN: otherwise, continue to next child
+                super.visit(pNode, ordinal, parent);
+            }
+        }.go(project.getInput(0)); // EXPLAIN: Project always has single child
+    }
+
     public static MultiCloudFieldSet findFields(final RelNode node) {
         //logger.debug("RelVisitor:Init");
 
         final Set<MultiCloudField<String, String, String>> usedFields = Sets.newLinkedHashSet();
 
         Set<RelOptTable> tables = Sets.newLinkedHashSet();
-        List<Pair<RexNode, String>> projects = new ArrayList<>();
+        List<RelDataTypeField> projects = new ArrayList<>();
         // TODO: Remove if not used
         RelWriter rw = new RelWriterImpl(new PrintWriter(System.out, true));
-        final int[] i = {0};
+        final int[] i = {0}; // EXPLAIN: Counter for the logger
 
         tables.addAll(findTables(node));// EXPLAIN: Get all the tables beforehand
 
@@ -67,83 +143,10 @@ public class MultiCloudDataManager {
                 }
 
                 if (node instanceof Project) { // EXPLAIN: if it's a Project, we want to find him a matching TableScan/Join to get Schema and Table information
-                    List<Pair<RexNode, String>> namedProjects = ((Project) node).getNamedProjects();
-                    projects.addAll(namedProjects);
+                    projects.addAll(getFields(node));
 
-                    new RelVisitor() {
+                    handle((Project) node);
 
-                        @Override
-                        // EXPLAIN: initial input is a child of pNode = project node. go through the tree and discover first scan, that should be the correct one
-                        public void visit(RelNode pNode, int ordinal, RelNode parent) {
-                            if (pNode instanceof TableScan) {
-                                // EXPLAIN: if it's a Table Scan, this is most likely the correct one
-
-                                final TableScan scan = (TableScan) pNode;
-                                // EXPLAIN: get information about table
-                                RelOptTable table = scan.getTable();
-                                String schemaName = table.getQualifiedName().get(0);
-                                String tableName = table.getQualifiedName().get(1);
-
-                                // TODO: add check that Project->Fields are subset of TableScan->Fields to confirm this is a correct TableScan - in case of Join, this is more complicated
-                                for (RelDataTypeField relDataTypeField : table.getRowType().getFieldList()) {
-                                    relDataTypeField.getName();
-                                }
-
-                                // EXPLAIN: go through the list of fields in Project and add them to the usedFields, together with discovered TableScan schema and table names.
-                                for (Pair<RexNode, String> field : namedProjects) {
-                                    String fieldName = field.getValue();
-                                    usedFields.add(MultiCloudField.of(schemaName, tableName, fieldName));
-                                }
-                            } else if (pNode instanceof Join) {
-                                // EXPLAIN: if it's a Join, we need to start new relVisitors on each branch
-                                // TODO: add relVisitors on each child branch of JOIN
-                                Join join = (Join) pNode;
-                                if (join.getInputs().size() != 2) {
-                                    // Bail out
-                                    throw new ReturnedValue(false);
-                                }
-
-                                // FIXME: ADD REAL HANDLERS FOR JOIN
-                                // TODO: join handler should look for tableScan, another join or project
-                                // First branch should have the query (with write ID filter conditions)
-                                new RelVisitor() {
-                                    @Override
-                                    public void visit(RelNode node, int ordinal, RelNode parent) {
-                                        if (node instanceof TableScan ||
-                                                node instanceof Filter ||
-                                                node instanceof Project ||
-                                                node instanceof Join) {
-                                            // We can continue
-                                            super.visit(node, ordinal, parent);
-                                        } else if (node instanceof Aggregate) {
-                                            // We can continue
-                                            super.visit(node, ordinal, parent);
-                                        } else {
-                                            throw new ReturnedValue(false);
-                                        }
-                                    }
-                                }.go(join.getInput(0));
-                                // Second branch should only have the MV
-                                new RelVisitor() {
-                                    @Override
-                                    public void visit(RelNode node, int ordinal, RelNode parent) {
-                                        if (node instanceof TableScan) {
-                                            // We can continue
-                                            // TODO: Need to check that this is the same MV that we are rebuilding
-                                            RelOptTable table = (RelOptTable) node.getTable();
-
-                                        } else if (node instanceof Project) {
-                                            // We can continue
-                                            super.visit(node, ordinal, parent);
-                                        }
-                                    }
-                                }.go(join.getInput(1));
-                            }
-
-                            // EXPLAIN: otherwise, continue to next child
-                            super.visit(pNode, ordinal, parent);
-                        }
-                    }.go(node.getInput(0)); // EXPLAIN: Project always has single child
                 } // EXPLAIN: I got all the projects
 
                 // TODO: can we map them now?
@@ -161,6 +164,9 @@ public class MultiCloudDataManager {
         return MultiCloudFieldSets.ofList(usedFields);
     }
 
+    private static List<RelDataTypeField> getFields(RelNode node){
+        return node.getRowType().getFieldList();
+    }
 
     /**
      * Exception used to interrupt a visitor walk.

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -1,5 +1,7 @@
 package cloud.sec.core.adapter.jdbc;
 
+import cloud.sec.core.tools.MultiCloudFieldSet;
+import cloud.sec.core.tools.MultiCloudFieldSets;
 import com.google.common.collect.Sets;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
@@ -40,7 +42,7 @@ public class MultiCloudDataManager {
         return tables;
     }
 
-    public static Set<MultiCloudField<String, String, String>> findFields(final RelNode node) {
+    public static MultiCloudFieldSet findFields(final RelNode node) {
         //logger.debug("RelVisitor:Init");
 
         final Set<MultiCloudField<String, String, String>> usedFields = Sets.newLinkedHashSet();
@@ -155,7 +157,8 @@ public class MultiCloudDataManager {
         logger.debug("RelVisitor:Done\n\t" + usedFields.stream()
                 .map(MultiCloudField::toString)
                 .collect(Collectors.joining("\n\t")));
-        return usedFields;
+
+        return MultiCloudFieldSets.ofList(usedFields);
     }
 
 

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudDataManager.java
@@ -46,7 +46,9 @@ public class MultiCloudDataManager {
 
                 if (node instanceof TableScan || node instanceof TableModify) {
                     tables.put(node.getTable(), getFieldNames(node));
-                    //TODO: if it's TableModify, insert fields right here
+                    //TODO: if it's TableModify INSERT, insert all table fields fields right here
+
+                    //TODO: if it's UPDATE, check operation=[UPDATE], updateColumnList=[[age]]
                 }
 
                 if (node instanceof Project) {

--- a/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudProgram.java
+++ b/core/src/main/java/cloud/sec/core/adapter/jdbc/MultiCloudProgram.java
@@ -1,5 +1,6 @@
 package cloud.sec.core.adapter.jdbc;
 
+import cloud.sec.core.tools.MultiCloudFieldSet;
 import org.apache.calcite.plan.RelOptLattice;
 import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -22,7 +23,7 @@ public class MultiCloudProgram implements Program {
     @Override
     public RelNode run(RelOptPlanner planner, RelNode rel, RelTraitSet requiredOutputTraits, List<RelOptMaterialization> materializations, List<RelOptLattice> lattices) {
         // TODO: make use of this
-        MultiCloudDataManager.findFields(rel);
+        MultiCloudFieldSet fields = MultiCloudDataManager.findFields(rel);
 
         return rel;
     }


### PR DESCRIPTION
In this pull request I've made extracting used fields #3 work for following type of queries:

```sql
-- scanProjectAll
SELECT * 
FROM cities;

-- scanJoinFilterProjectAll
SELECT * 
FROM cities, employees 
WHERE employees.city_id = cities.id;

-- scanProjectOne
SELECT `employees`.`age` 
FROM employees;

-- scanFilterProjectAll
SELECT * 
FROM employees 
WHERE `id` IN (100,2,3,4);

-- scanFilterProjectOne
SELECT `age` 
FROM employees 
WHERE `age` < 30;

-- scanFilterProjectTwo
SELECT `first`, `age` 
FROM employees 
WHERE `age` < 30;

-- tableModifyUpdate
UPDATE `mc_db`.`employees` 
SET `id` = 13, `age` = 25, `first` = 'Ivan', `last` = 'Grgurina', `city_id` = 1 
WHERE `id` = 13;

-- tableModifyUpdatePartial
UPDATE `mc_db`.`employees` 
SET `age` = 17 
WHERE `id` = 13;

-- tableModifyDelete
DELETE FROM `mc_db`.`employees` 
WHERE `id` = 13;
```

Only known case where this doesn't work:
```sql
-- tableModifyInsert
INSERT INTO `employees` (`id`, `age`,`first`,`last`,`city_id`) 
VALUES (13, 20, 'Ivan', 'Grgurina', 1);
```